### PR TITLE
Feature/user specific sourcing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/config.autosave
 tmux/tmux-resurrect
 tmux/tmux-resurrect-auto
+gitconfig_user

--- a/install
+++ b/install
@@ -163,6 +163,10 @@ _back_install() {
       ln -sf "$install_dir/symlinks/$1" "$HOME/.$1"
     fi
   fi
+
+  _print "Symlink user specific gitconfig"
+
+  ln -sf "$install_dir/users/$USER" "$HOME/.gitconfig.local"
 }
 
 for sym_file in $install_dir/symlinks/*

--- a/symlinks/gitconfig
+++ b/symlinks/gitconfig
@@ -29,9 +29,6 @@
 	mode = progress
 	editor = vim
   whitespace = fix,-indent-with-non-tab,trailing-space,cr-at-eol
-[github]
-	user = pierot
-	token = c9a84078efdf44e6cb4e534786f6991e
 [push]
 	default = current
 [alias]

--- a/symlinks/gitconfig
+++ b/symlinks/gitconfig
@@ -1,6 +1,5 @@
-[user]
-	name = Pieter Michels
-	email = pieter@noort.be
+[include]
+  path = ~/.gitconfig.local
 [apply]
   whitespace = fix
 [color]

--- a/users/jeroenb/gitconfig
+++ b/users/jeroenb/gitconfig
@@ -1,3 +1,5 @@
 [user]
 	name = Jeroen Bourgois
 	email = jeroenbourgois@gmail.com
+[github]
+	user = jeroenbourgois

--- a/users/jeroenb/gitconfig
+++ b/users/jeroenb/gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = Jeroen Bourgois
+	email = jeroenbourgois@gmail.com

--- a/users/pieterm/gitconfig
+++ b/users/pieterm/gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = Pieter Michels
+	email = pieter@noort.be

--- a/users/pieterm/gitconfig
+++ b/users/pieterm/gitconfig
@@ -1,3 +1,6 @@
 [user]
 	name = Pieter Michels
 	email = pieter@noort.be
+[github]
+	user = pierot
+	token = c9a84078efdf44e6cb4e534786f6991e


### PR DESCRIPTION
Eerste stap om user specifieke instellingen te kunnen hebben. Er bestaat nu op de root ook een `users` mapje met dan per user settings. Afhankelijk van het gebruik zal de installatiestap ook in de toekomst wat moeten worden geupdate, er is geen catch all denk ik. Git kan andere files includen, sommige tools (offlineimap) kunnen dat niet. Maar in deze PR dus: git config. Alles wat generiek staat zit in de oorspronkelijke symlink, enkel onze user credentials in de specifieke file.